### PR TITLE
op-node feat: Adds event parent for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ cross-op-node: ## Builds cross-platform Docker image for op-node
              fi) \
 	docker buildx bake \
 			--progress plain \
-			--builder=buildx-build \
 			--load \
 			--no-cache \
 			-f docker-bake.hcl \

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -123,7 +123,7 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 
 	// After having built a L2 block, make sure to get an engine update processed.
 	// This will ensure the sync-status and such reflect the latest changes.
-	s.synchronousEvents.Emit(engine.TryUpdateEngineEvent{})
+	s.synchronousEvents.Emit(engine.TryUpdateEngineEvent{ParentEv: "l2EndBlock"})
 	s.synchronousEvents.Emit(engine.ForkchoiceRequestEvent{})
 	require.NoError(t, s.drainer.DrainUntil(func(ev event.Event) bool {
 		x, ok := ev.(engine.ForkchoiceUpdateEvent)

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -61,10 +61,16 @@ func (eq *CLSync) LowestQueuedUnsafeBlock() eth.L2BlockRef {
 
 type ReceivedUnsafePayloadEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
+
+	ParentEv string
 }
 
 func (ev ReceivedUnsafePayloadEvent) String() string {
 	return "received-unsafe-payload"
+}
+
+func (ev ReceivedUnsafePayloadEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *CLSync) OnEvent(ev event.Event) bool {

--- a/op-node/rollup/clsync/clsync.go
+++ b/op-node/rollup/clsync/clsync.go
@@ -187,5 +187,5 @@ func (eq *CLSync) onUnsafePayload(x ReceivedUnsafePayloadEvent) {
 	eq.log.Trace("Next unsafe payload to process", "next", p.ExecutionPayload.ID(), "timestamp", uint64(p.ExecutionPayload.Timestamp))
 
 	// request forkchoice signal, so we can process the payload maybe
-	eq.emitter.Emit(engine.ForkchoiceRequestEvent{})
+	eq.emitter.Emit(engine.ForkchoiceRequestEvent{ParentEv: "unsafePayload"})
 }

--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -13,68 +13,116 @@ import (
 
 type DeriverIdleEvent struct {
 	Origin eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (d DeriverIdleEvent) String() string {
 	return "derivation-idle"
 }
 
+func (d DeriverIdleEvent) Parent() string {
+	return d.ParentEv
+}
+
 type DeriverL1StatusEvent struct {
 	Origin eth.L1BlockRef
 	LastL2 eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (d DeriverL1StatusEvent) String() string {
 	return "deriver-l1-status"
 }
 
-type DeriverMoreEvent struct{}
+func (d DeriverL1StatusEvent) Parent() string {
+	return d.ParentEv
+}
+
+type DeriverMoreEvent struct {
+	ParentEv string
+}
 
 func (d DeriverMoreEvent) String() string {
 	return "deriver-more"
 }
 
+func (d DeriverMoreEvent) Parent() string {
+	return d.ParentEv
+}
+
 // ConfirmReceivedAttributesEvent signals that the derivation pipeline may generate new attributes.
 // After emitting DerivedAttributesEvent, no new attributes will be generated until a confirmation of reception.
-type ConfirmReceivedAttributesEvent struct{}
+type ConfirmReceivedAttributesEvent struct {
+	ParentEv string
+}
 
 func (d ConfirmReceivedAttributesEvent) String() string {
 	return "confirm-received-attributes"
 }
 
-type ConfirmPipelineResetEvent struct{}
+func (d ConfirmReceivedAttributesEvent) Parent() string {
+	return d.ParentEv
+}
+
+type ConfirmPipelineResetEvent struct {
+	ParentEv string
+}
 
 func (d ConfirmPipelineResetEvent) String() string {
 	return "confirm-pipeline-reset"
 }
 
+func (d ConfirmPipelineResetEvent) Parent() string {
+	return d.ParentEv
+}
+
 // DerivedAttributesEvent is emitted when new attributes are available to apply to the engine.
 type DerivedAttributesEvent struct {
 	Attributes *AttributesWithParent
+
+	ParentEv string
 }
 
 func (ev DerivedAttributesEvent) String() string {
 	return "derived-attributes"
 }
 
+func (ev DerivedAttributesEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type PipelineStepEvent struct {
 	PendingSafe eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev PipelineStepEvent) String() string {
 	return "pipeline-step"
 }
 
+func (ev PipelineStepEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // DepositsOnlyPayloadAttributesRequestEvent requests a deposits-only version of the attributes from
 // the pipeline. It is sent by the engine deriver and received by the PipelineDeriver.
 // This event got introduced with Holocene.
 type DepositsOnlyPayloadAttributesRequestEvent struct {
-	Parent      eth.BlockID
+	ParentBlock eth.BlockID
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev DepositsOnlyPayloadAttributesRequestEvent) String() string {
 	return "deposits-only-payload-attributes-request"
+}
+
+func (ev DepositsOnlyPayloadAttributesRequestEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type PipelineDeriver struct {
@@ -146,7 +194,7 @@ func (d *PipelineDeriver) OnEvent(ev event.Event) bool {
 		d.needAttributesConfirmation = false
 	case DepositsOnlyPayloadAttributesRequestEvent:
 		d.pipeline.log.Warn("Deriving deposits-only attributes", "origin", d.pipeline.Origin())
-		attrib, err := d.pipeline.DepositsOnlyAttributes(x.Parent, x.DerivedFrom)
+		attrib, err := d.pipeline.DepositsOnlyAttributes(x.ParentBlock, x.DerivedFrom)
 		if err != nil {
 			d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("deriving deposits-only attributes: %w", err)})
 			return true

--- a/op-node/rollup/driver/steps.go
+++ b/op-node/rollup/driver/steps.go
@@ -10,38 +10,67 @@ import (
 )
 
 type ResetStepBackoffEvent struct {
+	ParentEv string
 }
 
 func (ev ResetStepBackoffEvent) String() string {
 	return "reset-step-backoff"
 }
 
+func (ev ResetStepBackoffEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type StepDelayedReqEvent struct {
 	Delay time.Duration
+
+	ParentEv string
 }
 
 func (ev StepDelayedReqEvent) String() string {
 	return "step-delayed-req"
 }
 
+func (ev StepDelayedReqEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type StepReqEvent struct {
 	ResetBackoff bool
+
+	ParentEv string
 }
 
 func (ev StepReqEvent) String() string {
 	return "step-req"
 }
 
-type StepAttemptEvent struct{}
+func (ev StepReqEvent) Parent() string {
+	return ev.ParentEv
+}
+
+type StepAttemptEvent struct {
+	ParentEv string
+}
 
 func (ev StepAttemptEvent) String() string {
 	return "step-attempt"
 }
 
-type StepEvent struct{}
+func (ev StepAttemptEvent) Parent() string {
+	return ev.ParentEv
+}
+
+type StepEvent struct {
+	ParentEv string
+}
 
 func (ev StepEvent) String() string {
 	return "step"
+}
+
+func (ev StepEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // StepSchedulingDeriver is a deriver that emits StepEvent events.

--- a/op-node/rollup/driver/steps.go
+++ b/op-node/rollup/driver/steps.go
@@ -167,7 +167,7 @@ func (s *StepSchedulingDeriver) OnEvent(ev event.Event) bool {
 		}
 		// count as attempt by default. We reset to 0 if we are making healthy progress.
 		s.stepAttempts += 1
-		s.emitter.Emit(StepEvent{})
+		s.emitter.Emit(StepEvent{ParentEv: "stepAttempt"})
 	case ResetStepBackoffEvent:
 		s.stepAttempts = 0
 	default:

--- a/op-node/rollup/engine/build_cancel.go
+++ b/op-node/rollup/engine/build_cancel.go
@@ -13,10 +13,16 @@ import (
 type BuildCancelEvent struct {
 	Info  eth.PayloadInfo
 	Force bool
+
+	ParnetEv string
 }
 
 func (ev BuildCancelEvent) String() string {
 	return "build-cancel"
+}
+
+func (ev BuildCancelEvent) Parent() string {
+	return ev.ParnetEv
 }
 
 func (eq *EngDeriver) onBuildCancel(ev BuildCancelEvent) {

--- a/op-node/rollup/engine/build_cancel.go
+++ b/op-node/rollup/engine/build_cancel.go
@@ -39,7 +39,7 @@ func (eq *EngDeriver) onBuildCancel(ev BuildCancelEvent) {
 		}
 		eq.log.Error("failed to cancel block building job", "info", ev.Info, "err", err)
 		if !ev.Force {
-			eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+			eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err, ParentEv: "buildCancel"})
 		}
 	}
 }

--- a/op-node/rollup/engine/build_invalid.go
+++ b/op-node/rollup/engine/build_invalid.go
@@ -13,20 +13,32 @@ import (
 type BuildInvalidEvent struct {
 	Attributes *derive.AttributesWithParent
 	Err        error
+
+	ParentEv string
 }
 
 func (ev BuildInvalidEvent) String() string {
 	return "build-invalid"
 }
 
+func (ev BuildInvalidEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // InvalidPayloadAttributesEvent is a signal to external derivers that the attributes were invalid.
 type InvalidPayloadAttributesEvent struct {
 	Attributes *derive.AttributesWithParent
 	Err        error
+
+	ParentEv string
 }
 
 func (ev InvalidPayloadAttributesEvent) String() string {
 	return "invalid-payload-attributes"
+}
+
+func (ev InvalidPayloadAttributesEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onBuildInvalid(ev BuildInvalidEvent) {
@@ -64,7 +76,7 @@ func (eq *EngDeriver) emitDepositsOnlyPayloadAttributesRequest(parent eth.BlockI
 	eq.log.Warn("Holocene active, requesting deposits-only attributes", "parent", parent, "derived_from", derivedFrom)
 	// request deposits-only version
 	eq.emitter.Emit(derive.DepositsOnlyPayloadAttributesRequestEvent{
-		Parent:      parent,
+		ParentBlock: parent,
 		DerivedFrom: derivedFrom,
 	})
 }

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -19,10 +19,16 @@ type PayloadSealInvalidEvent struct {
 
 	Concluding  bool
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev PayloadSealInvalidEvent) String() string {
 	return "payload-seal-invalid"
+}
+
+func (ev PayloadSealInvalidEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // PayloadSealExpiredErrorEvent identifies a form of failed payload-sealing that is not coupled
@@ -35,10 +41,16 @@ type PayloadSealExpiredErrorEvent struct {
 
 	Concluding  bool
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev PayloadSealExpiredErrorEvent) String() string {
 	return "payload-seal-expired-error"
+}
+
+func (ev PayloadSealExpiredErrorEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type BuildSealEvent struct {
@@ -48,10 +60,16 @@ type BuildSealEvent struct {
 	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev BuildSealEvent) String() string {
 	return "build-seal"
+}
+
+func (ev BuildSealEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -95,6 +95,7 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 			Err:         fmt.Errorf("failed to seal execution payload (ID: %s): %w", ev.Info.ID, err),
 			Concluding:  ev.Concluding,
 			DerivedFrom: ev.DerivedFrom,
+			ParentEv:    "BuildSeal",
 		})
 		return
 	}
@@ -141,5 +142,6 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 		Info:         ev.Info,
 		Envelope:     envelope,
 		Ref:          ref,
+		ParentEv:     "buildSeal",
 	})
 }

--- a/op-node/rollup/engine/build_sealed.go
+++ b/op-node/rollup/engine/build_sealed.go
@@ -18,10 +18,16 @@ type BuildSealedEvent struct {
 	Info     eth.PayloadInfo
 	Envelope *eth.ExecutionPayloadEnvelope
 	Ref      eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev BuildSealedEvent) String() string {
 	return "build-sealed"
+}
+
+func (ev BuildSealedEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onBuildSealed(ev BuildSealedEvent) {

--- a/op-node/rollup/engine/build_sealed.go
+++ b/op-node/rollup/engine/build_sealed.go
@@ -39,6 +39,7 @@ func (eq *EngDeriver) onBuildSealed(ev BuildSealedEvent) {
 			Envelope:     ev.Envelope,
 			Ref:          ev.Ref,
 			BuildStarted: ev.BuildStarted,
+			ParentEv:     "buildSealed",
 		})
 	}
 }

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -39,6 +39,7 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 		UnsafeL2Head:    ev.Attributes.Parent,
 		SafeL2Head:      eq.ec.safeHead,
 		FinalizedL2Head: eq.ec.finalizedHead,
+		ParentEv:        "buildStart",
 	}
 	if fcEvent.UnsafeL2Head.Number < fcEvent.FinalizedL2Head.Number {
 		err := fmt.Errorf("invalid block-building pre-state, unsafe head %s is behind finalized head %s", fcEvent.UnsafeL2Head, fcEvent.FinalizedL2Head)
@@ -56,16 +57,16 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 		switch errTyp {
 		case BlockInsertTemporaryErr:
 			// RPC errors are recoverable, we can retry the buffered payload attributes later.
-			eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: fmt.Errorf("temporarily cannot insert new safe block: %w", err)})
+			eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: fmt.Errorf("temporarily cannot insert new safe block: %w", err), ParentEv: "FCU"})
 			return
 		case BlockInsertPrestateErr:
-			eq.emitter.Emit(rollup.ResetEvent{Err: fmt.Errorf("need reset to resolve pre-state problem: %w", err)})
+			eq.emitter.Emit(rollup.ResetEvent{Err: fmt.Errorf("need reset to resolve pre-state problem: %w", err), ParentEv: "FCU"})
 			return
 		case BlockInsertPayloadErr:
-			eq.emitter.Emit(BuildInvalidEvent{Attributes: ev.Attributes, Err: err})
+			eq.emitter.Emit(BuildInvalidEvent{Attributes: ev.Attributes, Err: err, ParentEv: "FCU"})
 			return
 		default:
-			eq.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unknown error type %d: %w", errTyp, err)})
+			eq.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unknown error type %d: %w", errTyp, err), ParentEv: "FCU"})
 			return
 		}
 	}
@@ -77,5 +78,6 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 		Concluding:   ev.Attributes.Concluding,
 		DerivedFrom:  ev.Attributes.DerivedFrom,
 		ParentBlock:  ev.Attributes.Parent,
+		ParentEv:     "FCU",
 	})
 }

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -12,10 +12,16 @@ import (
 
 type BuildStartEvent struct {
 	Attributes *derive.AttributesWithParent
+
+	ParentEv string
 }
 
 func (ev BuildStartEvent) String() string {
 	return "build-start"
+}
+
+func (ev BuildStartEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
@@ -70,6 +76,6 @@ func (eq *EngDeriver) onBuildStart(ev BuildStartEvent) {
 		BuildStarted: buildStartTime,
 		Concluding:   ev.Attributes.Concluding,
 		DerivedFrom:  ev.Attributes.DerivedFrom,
-		Parent:       ev.Attributes.Parent,
+		ParentBlock:  ev.Attributes.Parent,
 	})
 }

--- a/op-node/rollup/engine/build_started.go
+++ b/op-node/rollup/engine/build_started.go
@@ -37,6 +37,7 @@ func (eq *EngDeriver) onBuildStarted(ev BuildStartedEvent) {
 			BuildStarted: ev.BuildStarted,
 			Concluding:   ev.Concluding,
 			DerivedFrom:  ev.DerivedFrom,
+			ParentEv:     "BuildStarted",
 		})
 	}
 }

--- a/op-node/rollup/engine/build_started.go
+++ b/op-node/rollup/engine/build_started.go
@@ -11,16 +11,22 @@ type BuildStartedEvent struct {
 
 	BuildStarted time.Time
 
-	Parent eth.L2BlockRef
+	ParentBlock eth.L2BlockRef
 
 	// if payload should be promoted to (local) safe (must also be pending safe, see DerivedFrom)
 	Concluding bool
 	// payload is promoted to pending-safe if non-zero
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev BuildStartedEvent) String() string {
 	return "build-started"
+}
+
+func (ev BuildStartedEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onBuildStarted(ev BuildStartedEvent) {

--- a/op-node/rollup/engine/engine_reset.go
+++ b/op-node/rollup/engine/engine_reset.go
@@ -14,10 +14,16 @@ import (
 // ResetEngineRequestEvent requests the EngineResetDeriver to walk
 // the L2 chain backwards until it finds a plausible unsafe head,
 // and find an L2 safe block that is guaranteed to still be from the L1 chain.
-type ResetEngineRequestEvent struct{}
+type ResetEngineRequestEvent struct {
+	ParentEv string
+}
 
 func (ev ResetEngineRequestEvent) String() string {
 	return "reset-engine-request"
+}
+
+func (ev ResetEngineRequestEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type EngineResetDeriver struct {

--- a/op-node/rollup/engine/engine_reset.go
+++ b/op-node/rollup/engine/engine_reset.go
@@ -65,6 +65,7 @@ func (d *EngineResetDeriver) OnEvent(ev event.Event) bool {
 			Unsafe:    result.Unsafe,
 			Safe:      result.Safe,
 			Finalized: result.Finalized,
+			ParentEv:  "ResetEngineRequest",
 		})
 	default:
 		return false

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -26,18 +26,29 @@ type Metrics interface {
 // forkchoice-update event, to signal the latest forkchoice to other derivers.
 // This helps decouple derivers from the actual engine state,
 // while also not making the derivers wait for a forkchoice update at random.
-type ForkchoiceRequestEvent struct{}
+type ForkchoiceRequestEvent struct {
+	ParentEv string
+}
 
 func (ev ForkchoiceRequestEvent) String() string {
 	return "forkchoice-request"
 }
 
+func (ev ForkchoiceRequestEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type ForkchoiceUpdateEvent struct {
 	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
+	ParentEv                                  string
 }
 
 func (ev ForkchoiceUpdateEvent) String() string {
 	return "forkchoice-update"
+}
+
+func (ev ForkchoiceUpdateEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // PromoteUnsafeEvent signals that the given block may now become a canonical unsafe block.
@@ -46,65 +57,105 @@ func (ev ForkchoiceUpdateEvent) String() string {
 // but manually, duplicate with the newer events processing code-path.
 // See EngineController.InsertUnsafePayload.
 type PromoteUnsafeEvent struct {
-	Ref eth.L2BlockRef
+	Ref      eth.L2BlockRef
+	ParentEv string
 }
 
 func (ev PromoteUnsafeEvent) String() string {
 	return "promote-unsafe"
 }
 
+func (ev PromoteUnsafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // RequestCrossUnsafeEvent signals that a CrossUnsafeUpdateEvent is needed.
-type RequestCrossUnsafeEvent struct{}
+type RequestCrossUnsafeEvent struct {
+	ParentEv string
+}
 
 func (ev RequestCrossUnsafeEvent) String() string {
 	return "request-cross-unsafe"
+}
+
+func (ev RequestCrossUnsafeEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // UnsafeUpdateEvent signals that the given block is now considered safe.
 // This is pre-forkchoice update; the change may not be reflected yet in the EL.
 type UnsafeUpdateEvent struct {
 	Ref eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev UnsafeUpdateEvent) String() string {
 	return "unsafe-update"
 }
 
+func (ev UnsafeUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // PromoteCrossUnsafeEvent signals that the given block may be promoted to cross-unsafe.
 type PromoteCrossUnsafeEvent struct {
-	Ref eth.L2BlockRef
+	Ref      eth.L2BlockRef
+	ParentEv string
 }
 
 func (ev PromoteCrossUnsafeEvent) String() string {
 	return "promote-cross-unsafe"
 }
 
+func (ev PromoteCrossUnsafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // CrossUnsafeUpdateEvent signals that the given block is now considered cross-unsafe.
 type CrossUnsafeUpdateEvent struct {
 	CrossUnsafe eth.L2BlockRef
 	LocalUnsafe eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev CrossUnsafeUpdateEvent) String() string {
 	return "cross-unsafe-update"
 }
 
+func (ev CrossUnsafeUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type PendingSafeUpdateEvent struct {
 	PendingSafe eth.L2BlockRef
 	Unsafe      eth.L2BlockRef // tip, added to the signal, to determine if there are existing blocks to consolidate
+
+	ParentEv string
 }
 
 func (ev PendingSafeUpdateEvent) String() string {
 	return "pending-safe-update"
 }
 
+func (ev PendingSafeUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type InteropPendingSafeChangedEvent struct {
 	Ref         eth.L2BlockRef
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev InteropPendingSafeChangedEvent) String() string {
 	return "interop-pending-safe-changed"
+}
+
+func (ev InteropPendingSafeChangedEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // PromotePendingSafeEvent signals that a block can be marked as pending-safe, and/or safe.
@@ -112,56 +163,92 @@ type PromotePendingSafeEvent struct {
 	Ref         eth.L2BlockRef
 	Concluding  bool // Concludes the pending phase, so can be promoted to (local) safe
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev PromotePendingSafeEvent) String() string {
 	return "promote-pending-safe"
 }
 
+func (ev PromotePendingSafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // PromoteLocalSafeEvent signals that a block can be promoted to local-safe.
 type PromoteLocalSafeEvent struct {
 	Ref         eth.L2BlockRef
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev PromoteLocalSafeEvent) String() string {
 	return "promote-local-safe"
 }
 
+func (ev PromoteLocalSafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // RequestCrossSafeEvent signals that a CrossSafeUpdate is needed.
-type RequestCrossSafeEvent struct{}
+type RequestCrossSafeEvent struct {
+	ParentEv string
+}
 
 func (ev RequestCrossSafeEvent) String() string {
 	return "request-cross-safe-update"
 }
 
+func (ev RequestCrossSafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type CrossSafeUpdateEvent struct {
 	CrossSafe eth.L2BlockRef
 	LocalSafe eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev CrossSafeUpdateEvent) String() string {
 	return "cross-safe-update"
 }
 
+func (ev CrossSafeUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // LocalSafeUpdateEvent signals that a block is now considered to be local-safe.
 type LocalSafeUpdateEvent struct {
 	Ref         eth.L2BlockRef
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev LocalSafeUpdateEvent) String() string {
 	return "local-safe-update"
 }
 
+func (ev LocalSafeUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // PromoteSafeEvent signals that a block can be promoted to cross-safe.
 type PromoteSafeEvent struct {
 	Ref         eth.L2BlockRef
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev PromoteSafeEvent) String() string {
 	return "promote-safe"
+}
+
+func (ev PromoteSafeEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // SafeDerivedEvent signals that a block was determined to be safe, and derived from the given L1 block.
@@ -169,39 +256,69 @@ func (ev PromoteSafeEvent) String() string {
 type SafeDerivedEvent struct {
 	Safe        eth.L2BlockRef
 	DerivedFrom eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev SafeDerivedEvent) String() string {
 	return "safe-derived"
 }
 
+func (ev SafeDerivedEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // ProcessAttributesEvent signals to immediately process the attributes.
 type ProcessAttributesEvent struct {
 	Attributes *derive.AttributesWithParent
+
+	ParentEv string
 }
 
 func (ev ProcessAttributesEvent) String() string {
 	return "process-attributes"
 }
 
-type PendingSafeRequestEvent struct{}
+func (ev ProcessAttributesEvent) Parent() string {
+	return ev.ParentEv
+}
+
+type PendingSafeRequestEvent struct {
+	ParentEv string
+}
 
 func (ev PendingSafeRequestEvent) String() string {
 	return "pending-safe-request"
 }
 
+func (ev PendingSafeRequestEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type ProcessUnsafePayloadEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
+
+	ParentEv string
 }
 
 func (ev ProcessUnsafePayloadEvent) String() string {
 	return "process-unsafe-payload"
 }
 
-type TryBackupUnsafeReorgEvent struct{}
+func (ev ProcessUnsafePayloadEvent) Parent() string {
+	return ev.ParentEv
+}
+
+type TryBackupUnsafeReorgEvent struct {
+	ParentEv string
+}
 
 func (ev TryBackupUnsafeReorgEvent) String() string {
 	return "try-backup-unsafe-reorg"
+}
+
+func (ev TryBackupUnsafeReorgEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type TryUpdateEngineEvent struct {
@@ -210,10 +327,16 @@ type TryUpdateEngineEvent struct {
 	BuildStarted  time.Time
 	InsertStarted time.Time
 	Envelope      *eth.ExecutionPayloadEnvelope
+
+	ParentEv string
 }
 
 func (ev TryUpdateEngineEvent) String() string {
 	return "try-update-engine"
+}
+
+func (ev TryUpdateEngineEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // Checks for the existence of the Envelope field, which is only
@@ -267,53 +390,88 @@ func (ev TryUpdateEngineEvent) getBlockProcessingMetrics() []interface{} {
 
 type ForceEngineResetEvent struct {
 	Unsafe, Safe, Finalized eth.L2BlockRef
+	ParentEv                string
 }
 
 func (ev ForceEngineResetEvent) String() string {
 	return "force-engine-reset"
 }
 
+func (ev ForceEngineResetEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type EngineResetConfirmedEvent struct {
 	Unsafe, Safe, Finalized eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev EngineResetConfirmedEvent) String() string {
 	return "engine-reset-confirmed"
 }
 
+func (ev EngineResetConfirmedEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // PromoteFinalizedEvent signals that a block can be marked as finalized.
 type PromoteFinalizedEvent struct {
 	Ref eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev PromoteFinalizedEvent) String() string {
 	return "promote-finalized"
 }
 
+func (ev PromoteFinalizedEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // FinalizedUpdateEvent signals that a block has been marked as finalized.
 type FinalizedUpdateEvent struct {
 	Ref eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev FinalizedUpdateEvent) String() string {
 	return "finalized-update"
 }
 
+func (ev FinalizedUpdateEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // RequestFinalizedUpdateEvent signals that a FinalizedUpdateEvent is needed.
-type RequestFinalizedUpdateEvent struct{}
+type RequestFinalizedUpdateEvent struct {
+	ParentEv string
+}
 
 func (ev RequestFinalizedUpdateEvent) String() string {
 	return "request-finalized-update"
+}
+
+func (ev RequestFinalizedUpdateEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // CrossUpdateRequestEvent triggers update events to be emitted, repeating the current state.
 type CrossUpdateRequestEvent struct {
 	CrossUnsafe bool
 	CrossSafe   bool
+
+	ParentEv string
 }
 
 func (ev CrossUpdateRequestEvent) String() string {
 	return "cross-update-request"
+}
+
+func (ev CrossUpdateRequestEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type EngDeriver struct {

--- a/op-node/rollup/engine/payload_invalid.go
+++ b/op-node/rollup/engine/payload_invalid.go
@@ -5,10 +5,16 @@ import "github.com/ethereum-optimism/optimism/op-service/eth"
 type PayloadInvalidEvent struct {
 	Envelope *eth.ExecutionPayloadEnvelope
 	Err      error
+
+	ParentEv string
 }
 
 func (ev PayloadInvalidEvent) String() string {
 	return "payload-invalid"
+}
+
+func (ev PayloadInvalidEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onPayloadInvalid(ev PayloadInvalidEvent) {

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -18,10 +18,16 @@ type PayloadProcessEvent struct {
 
 	Envelope *eth.ExecutionPayloadEnvelope
 	Ref      eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev PayloadProcessEvent) String() string {
 	return "payload-process"
+}
+
+func (ev PayloadProcessEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onPayloadProcess(ev PayloadProcessEvent) {

--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -39,7 +39,8 @@ func (eq *EngDeriver) onPayloadProcess(ev PayloadProcessEvent) {
 		ev.Envelope.ExecutionPayload, ev.Envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{
-			Err: fmt.Errorf("failed to insert execution payload: %w", err),
+			Err:      fmt.Errorf("failed to insert execution payload: %w", err),
+			ParentEv: "payloadProcess",
 		})
 		return
 	}
@@ -55,6 +56,7 @@ func (eq *EngDeriver) onPayloadProcess(ev PayloadProcessEvent) {
 		eq.emitter.Emit(PayloadInvalidEvent{
 			Envelope: ev.Envelope,
 			Err:      eth.NewPayloadErr(ev.Envelope.ExecutionPayload, status),
+			ParentEv: "payloadProcess",
 		})
 		return
 	case eth.ExecutionValid:

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -16,10 +16,16 @@ type PayloadSuccessEvent struct {
 
 	Envelope *eth.ExecutionPayloadEnvelope
 	Ref      eth.L2BlockRef
+
+	ParentEv string
 }
 
 func (ev PayloadSuccessEvent) String() string {
 	return "payload-success"
+}
+
+func (ev PayloadSuccessEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -37,6 +37,7 @@ func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
 			Ref:         ev.Ref,
 			Concluding:  ev.Concluding,
 			DerivedFrom: ev.DerivedFrom,
+			ParentEv:    "payloadSuccess",
 		})
 	}
 
@@ -44,5 +45,6 @@ func (eq *EngDeriver) onPayloadSuccess(ev PayloadSuccessEvent) {
 		BuildStarted:  ev.BuildStarted,
 		InsertStarted: ev.InsertStarted,
 		Envelope:      ev.Envelope,
+		ParentEv:      "PayloadSuccess",
 	})
 }

--- a/op-node/rollup/event.go
+++ b/op-node/rollup/event.go
@@ -4,7 +4,8 @@ import "github.com/ethereum-optimism/optimism/op-node/rollup/event"
 
 // L1TemporaryErrorEvent identifies a temporary issue with the L1 data.
 type L1TemporaryErrorEvent struct {
-	Err error
+	Err      error
+	ParentEv string
 }
 
 var _ event.Event = L1TemporaryErrorEvent{}
@@ -13,12 +14,17 @@ func (ev L1TemporaryErrorEvent) String() string {
 	return "l1-temporary-error"
 }
 
+func (ev L1TemporaryErrorEvent) Parent() string {
+	return ev.ParentEv
+}
+
 // EngineTemporaryErrorEvent identifies a temporary processing issue.
 // It applies to both L1 and L2 data, often inter-related.
 // This scope will be reduced over time, to only capture L2-engine specific temporary errors.
 // See L1TemporaryErrorEvent for L1 related temporary errors.
 type EngineTemporaryErrorEvent struct {
-	Err error
+	Err      error
+	ParentEv string
 }
 
 var _ event.Event = EngineTemporaryErrorEvent{}
@@ -27,14 +33,23 @@ func (ev EngineTemporaryErrorEvent) String() string {
 	return "engine-temporary-error"
 }
 
+func (ev EngineTemporaryErrorEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type ResetEvent struct {
-	Err error
+	Err      error
+	ParentEv string
 }
 
 var _ event.Event = ResetEvent{}
 
 func (ev ResetEvent) String() string {
 	return "reset-event"
+}
+
+func (ev ResetEvent) Parent() string {
+	return ev.ParentEv
 }
 
 // CriticalErrorEvent is an alias for event.CriticalErrorEvent

--- a/op-node/rollup/event/events.go
+++ b/op-node/rollup/event/events.go
@@ -7,6 +7,8 @@ type Event interface {
 	// The name must be simple and identify the event type, not the event content.
 	// This name is used for metric-labeling.
 	String() string
+	// Returns the parent of the event if it exists, root otherwise
+	Parent() string
 }
 
 type Deriver interface {
@@ -77,11 +79,16 @@ type NoopEmitter struct{}
 func (e NoopEmitter) Emit(ev Event) {}
 
 type CriticalErrorEvent struct {
-	Err error
+	Err      error
+	ParentEv string
 }
 
 var _ Event = CriticalErrorEvent{}
 
 func (ev CriticalErrorEvent) String() string {
 	return "critical-error"
+}
+
+func (ev CriticalErrorEvent) Parent() string {
+	return ev.ParentEv
 }

--- a/op-node/rollup/event/events_test.go
+++ b/op-node/rollup/event/events_test.go
@@ -7,10 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type TestEvent struct{}
+type TestEvent struct {
+	ParentEv string
+}
 
 func (ev TestEvent) String() string {
 	return "X"
+}
+
+func (ev TestEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func TestDeriverMux_OnEvent(t *testing.T) {

--- a/op-node/rollup/event/executor_global.go
+++ b/op-node/rollup/event/executor_global.go
@@ -78,6 +78,7 @@ func (gs *GlobalSyncExec) pop() AnnotatedEvent {
 func (gs *GlobalSyncExec) processEvent(ev AnnotatedEvent) {
 	gs.handlesLock.RLock() // read lock, to allow Drain() to be called during event processing.
 	defer gs.handlesLock.RUnlock()
+	// fmt.Println("Processing: ", ev.Event.String(), " Parent", ev.Event.Parent())
 	for _, h := range gs.handles {
 		h.onEvent(ev)
 	}

--- a/op-node/rollup/event/executor_global_test.go
+++ b/op-node/rollup/event/executor_global_test.go
@@ -59,11 +59,16 @@ func TestQueueSanityLimit(t *testing.T) {
 }
 
 type CyclicEvent struct {
-	Count int
+	Count    int
+	ParentEv string
 }
 
 func (ev CyclicEvent) String() string {
 	return "cyclic-event"
+}
+
+func (ev CyclicEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func TestSynchronousCyclic(t *testing.T) {

--- a/op-node/rollup/event/util_test.go
+++ b/op-node/rollup/event/util_test.go
@@ -6,16 +6,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type FooEvent struct{}
+type FooEvent struct {
+	ParentEv string
+}
 
 func (ev FooEvent) String() string {
 	return "foo"
 }
 
-type BarEvent struct{}
+func (ev FooEvent) Parent() string {
+	return ev.ParentEv
+}
+
+type BarEvent struct {
+	ParentEv string
+}
 
 func (ev BarEvent) String() string {
 	return "bar"
+}
+
+func (ev BarEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func TestIs(t *testing.T) {

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -189,7 +189,7 @@ func (fi *Finalizer) onL1Finalized(l1Origin eth.L1BlockRef) {
 	}
 
 	// when the L1 change we can suggest to try to finalize, as the pre-condition for L2 finality has now changed
-	fi.emitter.Emit(TryFinalizeEvent{})
+	fi.emitter.Emit(TryFinalizeEvent{ParentEv: "l1Finalize"})
 }
 
 // onDerivationIdle is called when the pipeline is exhausted of new data (i.e. no more L2 blocks to derive from).
@@ -212,7 +212,7 @@ func (fi *Finalizer) onDerivationIdle(derivedFrom eth.L1BlockRef) {
 	}
 	fi.log.Debug("processing L1 finality information", "l1_finalized", fi.finalizedL1, "derived_from", derivedFrom, "previous", fi.triedFinalizeAt)
 	fi.triedFinalizeAt = derivedFrom.Number
-	fi.emitter.Emit(TryFinalizeEvent{})
+	fi.emitter.Emit(TryFinalizeEvent{ParentEv: "derivationIdle"})
 }
 
 func (fi *Finalizer) tryFinalize() {

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -125,16 +125,28 @@ func (fi *Finalizer) FinalizedL1() (out eth.L1BlockRef) {
 
 type FinalizeL1Event struct {
 	FinalizedL1 eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev FinalizeL1Event) String() string {
 	return "finalized-l1"
 }
 
-type TryFinalizeEvent struct{}
+func (ev FinalizeL1Event) Parent() string {
+	return ev.ParentEv
+}
+
+type TryFinalizeEvent struct {
+	ParentEv string
+}
 
 func (ev TryFinalizeEvent) String() string {
 	return "try-finalize"
+}
+
+func (ev TryFinalizeEvent) Parent() string {
+	return ev.ParentEv
 }
 
 func (fi *Finalizer) OnEvent(ev event.Event) bool {

--- a/op-node/rollup/interop/interop.go
+++ b/op-node/rollup/interop/interop.go
@@ -195,7 +195,7 @@ func (d *InteropDeriver) onCrossUnsafe(x engine.CrossUnsafeUpdateEvent) error {
 	if err != nil {
 		return fmt.Errorf("failed to get cross-unsafe block info of %s: %w", result.Cross, err)
 	}
-	d.emitter.Emit(engine.PromoteCrossUnsafeEvent{Ref: ref})
+	d.emitter.Emit(engine.PromoteCrossUnsafeEvent{Ref: ref, ParentEv: "crossUnsafe"})
 
 	return nil
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -215,8 +215,9 @@ func (d *Sequencer) onBuildStarted(x engine.BuildStartedEvent) {
 		d.log.Warn("Canceling stale block-building job that was just started, as target to build onto has changed",
 			"stale", x.Parent, "new", d.latest.Onto, "job_id", x.Info.ID, "job_timestamp", x.Info.Timestamp)
 		d.emitter.Emit(engine.BuildCancelEvent{
-			Info:  x.Info,
-			Force: true,
+			Info:     x.Info,
+			Force:    true,
+			ParnetEv: "buildStarted",
 		})
 		d.handleInvalid()
 		return
@@ -277,7 +278,8 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 	defer cancel()
 	if err := d.conductor.CommitUnsafePayload(ctx, x.Envelope); err != nil {
 		d.emitter.Emit(rollup.EngineTemporaryErrorEvent{
-			Err: fmt.Errorf("failed to commit unsafe payload to conductor: %w", err),
+			Err:      fmt.Errorf("failed to commit unsafe payload to conductor: %w", err),
+			ParentEv: "BuildSealed",
 		})
 		return
 	}
@@ -293,6 +295,7 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 		BuildStarted: x.BuildStarted,
 		Envelope:     x.Envelope,
 		Ref:          x.Ref,
+		ParentEv:     "BuildSealed",
 	})
 	d.latest.Ref = x.Ref
 	d.latestSealed = x.Ref
@@ -368,6 +371,7 @@ func (d *Sequencer) onSequencerAction(SequencerActionEvent) {
 			DerivedFrom: eth.L1BlockRef{},
 			Envelope:    payload,
 			Ref:         ref,
+			ParentEv:    "SequencerAction()",
 		})
 		d.latest.Ref = ref
 	} else {
@@ -381,6 +385,7 @@ func (d *Sequencer) onSequencerAction(SequencerActionEvent) {
 				BuildStarted: d.latest.Started,
 				Concluding:   false,
 				DerivedFrom:  eth.L1BlockRef{},
+				ParentEv:     "SequencerAction()",
 			})
 		} else if d.latest == (BuildingState{}) {
 			// If we have not started building anything, start building.
@@ -417,7 +422,7 @@ func (d *Sequencer) onReset(x rollup.ResetEvent) {
 	d.metrics.RecordSequencerReset()
 	// try to cancel any ongoing payload building job
 	if d.latest.Info != (eth.PayloadInfo{}) {
-		d.emitter.Emit(engine.BuildCancelEvent{Info: d.latest.Info})
+		d.emitter.Emit(engine.BuildCancelEvent{Info: d.latest.Info, ParnetEv: "reset"})
 	}
 	d.latest = BuildingState{}
 	// no action to perform until we get a reset-confirmation
@@ -486,7 +491,7 @@ func (d *Sequencer) startBuildingBlock() {
 
 	// If we do not have data to know what to build on, then request a forkchoice update
 	if l2Head == (eth.L2BlockRef{}) {
-		d.emitter.Emit(engine.ForkchoiceRequestEvent{})
+		d.emitter.Emit(engine.ForkchoiceRequestEvent{ParentEv: "StartBuildingBlock()"})
 		return
 	}
 	// If we have already started trying to build on top of this block, we can avoid starting over again.
@@ -517,16 +522,16 @@ func (d *Sequencer) startBuildingBlock() {
 	attrs, err := d.attrBuilder.PreparePayloadAttributes(fetchCtx, l2Head, l1Origin.ID())
 	if err != nil {
 		if errors.Is(err, derive.ErrTemporary) {
-			d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err})
+			d.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: err, ParentEv: "StartBuildingBlock()"})
 			return
 		} else if errors.Is(err, derive.ErrReset) {
-			d.emitter.Emit(rollup.ResetEvent{Err: err})
+			d.emitter.Emit(rollup.ResetEvent{Err: err, ParentEv: "StartBuildingBlock()"})
 			return
 		} else if errors.Is(err, derive.ErrCritical) {
-			d.emitter.Emit(rollup.CriticalErrorEvent{Err: err})
+			d.emitter.Emit(rollup.CriticalErrorEvent{Err: err, ParentEv: "StartBuildingBlock()"})
 			return
 		} else {
-			d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected attributes-preparation error: %w", err)})
+			d.emitter.Emit(rollup.CriticalErrorEvent{Err: fmt.Errorf("unexpected attributes-preparation error: %w", err), ParentEv: "StartBuildingBlock()"})
 			return
 		}
 	}
@@ -575,6 +580,7 @@ func (d *Sequencer) startBuildingBlock() {
 
 	d.emitter.Emit(engine.BuildStartEvent{
 		Attributes: withParent,
+		ParentEv:   "StartBuildingBlock()",
 	})
 }
 

--- a/op-node/rollup/sequencing/sequencer_chaos_test.go
+++ b/op-node/rollup/sequencing/sequencer_chaos_test.go
@@ -90,7 +90,7 @@ func (c *ChaoticEngine) OnEvent(ev event.Event) bool {
 			c.emitter.Emit(engine.BuildStartedEvent{
 				Info:         c.currentPayloadInfo,
 				BuildStarted: c.clock.Now(),
-				Parent:       x.Attributes.Parent,
+				ParentBlock:  x.Attributes.Parent,
 				Concluding:   false,
 				DerivedFrom:  eth.L1BlockRef{},
 			})

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -315,7 +315,7 @@ func TestSequencer_StaleBuild(t *testing.T) {
 	seq.OnEvent(engine.BuildStartedEvent{
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
-		Parent:       head,
+		ParentBlock:  head,
 		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})
@@ -521,7 +521,7 @@ func TestSequencerBuild(t *testing.T) {
 	seq.OnEvent(engine.BuildStartedEvent{
 		Info:         payloadInfo,
 		BuildStarted: startedTime,
-		Parent:       head,
+		ParentBlock:  head,
 		Concluding:   false,
 		DerivedFrom:  eth.L1BlockRef{},
 	})

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -16,18 +16,30 @@ import (
 
 type L1UnsafeEvent struct {
 	L1Unsafe eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev L1UnsafeEvent) String() string {
 	return "l1-unsafe"
 }
 
+func (ev L1UnsafeEvent) Parent() string {
+	return ev.ParentEv
+}
+
 type L1SafeEvent struct {
 	L1Safe eth.L1BlockRef
+
+	ParentEv string
 }
 
 func (ev L1SafeEvent) String() string {
 	return "l1-safe"
+}
+
+func (ev L1SafeEvent) Parent() string {
+	return ev.ParentEv
 }
 
 type Metrics interface {

--- a/op-program/client/driver/program_test.go
+++ b/op-program/client/driver/program_test.go
@@ -154,8 +154,14 @@ func TestProgramDeriver(t *testing.T) {
 	})
 }
 
-type TestEvent struct{}
+type TestEvent struct {
+	ParentEv string
+}
 
 func (ev TestEvent) String() string {
 	return "test-event"
+}
+
+func (ev TestEvent) Parent() string {
+	return ev.ParentEv
 }


### PR DESCRIPTION
This PR adds parent field to the event type. When an event is emmitted, the parent is added. It helps to understand the control flow of the program. Plus, it makes debugging easier.